### PR TITLE
fix: prevent iOS auto-zoom on input focus

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -24,7 +24,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       },
       {
         name: "viewport",
-        content: "width=device-width, initial-scale=1",
+        content: "width=device-width, initial-scale=1, maximum-scale=1",
       },
       {
         title: "Spotify Stats",


### PR DESCRIPTION
Adds `maximum-scale=1` to the viewport meta tag so iOS Safari does not auto-zoom when the user taps into the search input field.

Closes #7

Generated with [Claude Code](https://claude.ai/code)