### PR TITLE
feat: prefetch top artists and top tracks automatically

### DIFF
--- a/src/lib/spotify/auth/auth-context.tsx
+++ b/src/lib/spotify/auth/auth-context.tsx
@@ -15,6 +15,11 @@ import {
   login as spotifyLogin,
   logout as spotifyLogout,
 } from "@/lib/spotify/auth/oauth"
+import { topArtistsQueryOptions } from "@/lib/spotify/api/me/top-artists"
+import { topTracksQueryOptions } from "@/lib/spotify/api/me/top-tracks"
+import type { TimeRange } from "@/lib/spotify/api/me/top-artists"
+
+const TIME_RANGES: Array<TimeRange> = ["short_term", "medium_term", "long_term"]
 
 const TOKEN_STORAGE_KEY = "spotify_access_token"
 
@@ -78,6 +83,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     queryClient.removeQueries({ queryKey: meQueryOptions.queryKey })
     setStorageVersion((v) => v + 1)
   }, [queryClient])
+
+  useEffect(() => {
+    if (!state.isAuthenticated) return
+    for (const timeRange of TIME_RANGES) {
+      queryClient.prefetchQuery(topArtistsQueryOptions(timeRange))
+      queryClient.prefetchQuery(topTracksQueryOptions(timeRange))
+    }
+  }, [state.isAuthenticated, queryClient])
 
   const value: AuthContextValue = {
     ...state,


### PR DESCRIPTION
Prefetch all three time ranges (short_term, medium_term, long_term) for top artists and top tracks as soon as the user authenticates, so tab and filter switching is instant.

Closes #21

Generated with [Claude Code](https://claude.ai/code)